### PR TITLE
Refactor servlets to use Jakarta EE and update project configuration

### DIFF
--- a/src/com/shashi/servlets/AddTrainFwd.java
+++ b/src/com/shashi/servlets/AddTrainFwd.java
@@ -2,15 +2,13 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.shashi.constant.UserRole;
-import com.shashi.utility.TrainUtil;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("serial")
 @WebServlet("/addtrainfwd")

--- a/src/com/shashi/servlets/AdminAddTrain.java
+++ b/src/com/shashi/servlets/AdminAddTrain.java
@@ -3,13 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;
 import com.shashi.constant.ResponseCode;

--- a/src/com/shashi/servlets/AdminCancleTrain.java
+++ b/src/com/shashi/servlets/AdminCancleTrain.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainException;
 import com.shashi.constant.ResponseCode;

--- a/src/com/shashi/servlets/AdminCancleTrainFwd.java
+++ b/src/com/shashi/servlets/AdminCancleTrainFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/AdminLogin.java
+++ b/src/com/shashi/servlets/AdminLogin.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainException;
 import com.shashi.constant.UserRole;

--- a/src/com/shashi/servlets/AdminLogoutServlet.java
+++ b/src/com/shashi/servlets/AdminLogoutServlet.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/AdminSearchTrain.java
+++ b/src/com/shashi/servlets/AdminSearchTrain.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/AdminSearchTrainFwd.java
+++ b/src/com/shashi/servlets/AdminSearchTrainFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/AdminTrainUpdate.java
+++ b/src/com/shashi/servlets/AdminTrainUpdate.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/AdminTrainUpdateFwd.java
+++ b/src/com/shashi/servlets/AdminTrainUpdateFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("serial")
 @WebServlet("/updatetrain")

--- a/src/com/shashi/servlets/AdminViewLinkFwd.java
+++ b/src/com/shashi/servlets/AdminViewLinkFwd.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/AdminViewTrainFwd.java
+++ b/src/com/shashi/servlets/AdminViewTrainFwd.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/BookTrainByRef.java
+++ b/src/com/shashi/servlets/BookTrainByRef.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.LocalDate;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/BookTrainFwd.java
+++ b/src/com/shashi/servlets/BookTrainFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/BookTrainPayment.java
+++ b/src/com/shashi/servlets/BookTrainPayment.java
@@ -2,13 +2,13 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/BookTrains.java
+++ b/src/com/shashi/servlets/BookTrains.java
@@ -5,13 +5,13 @@ import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.HistoryBean;
 import com.shashi.beans.TrainBean;

--- a/src/com/shashi/servlets/ChangeUserPassword.java
+++ b/src/com/shashi/servlets/ChangeUserPassword.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/ChangeUserPwd.java
+++ b/src/com/shashi/servlets/ChangeUserPwd.java
@@ -3,13 +3,13 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-//import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainException;
 import com.shashi.beans.UserBean;

--- a/src/com/shashi/servlets/EditUserProfile.java
+++ b/src/com/shashi/servlets/EditUserProfile.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.UserBean;
 import com.shashi.constant.UserRole;

--- a/src/com/shashi/servlets/ErrorHandlerServlet.java
+++ b/src/com/shashi/servlets/ErrorHandlerServlet.java
@@ -4,11 +4,11 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Optional;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainException;
 import com.shashi.constant.ResponseCode;
@@ -25,10 +25,10 @@ public class ErrorHandlerServlet extends HttpServlet {
 		res.setContentType("text/html");
 
 		// Fetch the exceptions
-		Throwable throwable = (Throwable) req.getAttribute("javax.servlet.error.exception");
-		Integer statusCode = (Integer) req.getAttribute("javax.servlet.error.status_code");
-		String servletName = (String) req.getAttribute("javax.servlet.error.servlet_name");
-		String requestUri = (String) req.getAttribute("javax.servlet.error.request_uri");
+		Throwable throwable = (Throwable) req.getAttribute("jakarta.servlet.error.exception");
+		Integer statusCode = (Integer) req.getAttribute("jakarta.servlet.error.status_code");
+		String servletName = (String) req.getAttribute("jakarta.servlet.error.servlet_name");
+		String requestUri = (String) req.getAttribute("jakarta.servlet.error.request_uri");
 		String errorMessage = ResponseCode.INTERNAL_SERVER_ERROR.getMessage();
 		String errorCode = ResponseCode.INTERNAL_SERVER_ERROR.name();
 

--- a/src/com/shashi/servlets/FareEnq.java
+++ b/src/com/shashi/servlets/FareEnq.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/FareEnqFwd.java
+++ b/src/com/shashi/servlets/FareEnqFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/TicketBookingHistory.java
+++ b/src/com/shashi/servlets/TicketBookingHistory.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.HistoryBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/TrainBwStn.java
+++ b/src/com/shashi/servlets/TrainBwStn.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/TrainBwStnFwd.java
+++ b/src/com/shashi/servlets/TrainBwStnFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/UpdateTrainSchedule.java
+++ b/src/com/shashi/servlets/UpdateTrainSchedule.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/UpdateUserProfile.java
+++ b/src/com/shashi/servlets/UpdateUserProfile.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainException;
 import com.shashi.beans.UserBean;

--- a/src/com/shashi/servlets/UserAvailFwd.java
+++ b/src/com/shashi/servlets/UserAvailFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/UserAvailServlet.java
+++ b/src/com/shashi/servlets/UserAvailServlet.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/UserHome.java
+++ b/src/com/shashi/servlets/UserHome.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/UserLoginServlet.java
+++ b/src/com/shashi/servlets/UserLoginServlet.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.ResponseCode;
 import com.shashi.constant.UserRole;

--- a/src/com/shashi/servlets/UserLogoutServlet.java
+++ b/src/com/shashi/servlets/UserLogoutServlet.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/UserProfile.java
+++ b/src/com/shashi/servlets/UserProfile.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/UserRegServlet.java
+++ b/src/com/shashi/servlets/UserRegServlet.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainException;
 import com.shashi.beans.UserBean;

--- a/src/com/shashi/servlets/UserSearchFwd.java
+++ b/src/com/shashi/servlets/UserSearchFwd.java
@@ -2,12 +2,12 @@ package com.shashi.servlets;
 
 import java.io.IOException;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.constant.UserRole;
 import com.shashi.utility.TrainUtil;

--- a/src/com/shashi/servlets/UserSearchTrain.java
+++ b/src/com/shashi/servlets/UserSearchTrain.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/UserViewLinkGet.java
+++ b/src/com/shashi/servlets/UserViewLinkGet.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/UserViewTrainFwd.java
+++ b/src/com/shashi/servlets/UserViewTrainFwd.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.TrainBean;
 import com.shashi.beans.TrainException;

--- a/src/com/shashi/servlets/ViewUserProfile.java
+++ b/src/com/shashi/servlets/ViewUserProfile.java
@@ -3,12 +3,12 @@ package com.shashi.servlets;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.shashi.beans.UserBean;
 import com.shashi.constant.UserRole;


### PR DESCRIPTION
- Updated servlet imports from javax.servlet to jakarta.servlet in multiple servlet classes.
- Added new classpath entries for generated sources in .classpath.
- Modified .project file to include filtered resources for node_modules and .git.
- Adjusted project facets in .settings/org.eclipse.wst.common.project.facet.core.xml.
- Updated servlet API dependency in .settings/org.eclipse.wst.common.component.
- Disabled annotation processing in .settings/org.eclipse.jdt.core.prefs.
- Created new .settings/org.eclipse.jdt.apt.core.prefs file to manage annotation processing settings.
- Added a placeholder WebServlet annotation class.